### PR TITLE
Throw specific error on JSON read timeouts

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "devDependencies": {
     "6to5ify": "^3.1.2",
     "browserify": "^8.1.0",
-    "chai": "^1.10.0",
+    "chai": "^3.0.0",
+    "chai-as-promised": "^5.1.0",
     "es6-promise": "^2.0.1",
     "isomorphic-fetch": "^2.0.0",
     "jshint": "^2.5.11",

--- a/src/fetchres.js
+++ b/src/fetchres.js
@@ -9,6 +9,9 @@ export function json(response) {
 	}
 	return response.json()
 		.catch(function(err) {
+			if (err.message.indexOf('response timeout at') === 0) {
+				throw new ReadTimeoutError(err.message);
+			}
 			// probably invalid json
 			throw new InvalidJsonError(err.message);
 		});
@@ -33,6 +36,12 @@ export class BadServerResponseError extends Error {
 }
 
 export class InvalidJsonError extends Error {
+	constructor(options) {
+		this.message = options;
+	}
+}
+
+export class ReadTimeoutError extends Error {
 	constructor(options) {
 		this.message = options;
 	}

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -4,7 +4,10 @@ require('es6-promise').polyfill();
 require('isomorphic-fetch');
 var fetchRes = require('../lib/fetchres');
 
-var expect = require('chai').expect;
+var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
+var expect = chai.expect;
 var nock = require('nock');
 var good = 'hello world. 你好世界。';
 var bad = 'good bye cruel world. 再见残酷的世界。';
@@ -101,14 +104,10 @@ describe('fetch', function() {
 		var response = {
 			ok: true,
 			json: function() {
-				return Promise.reject(new Error('response timeout at ...'));
+				return Promise.reject(new Error('response timeout at...'));
 			}
 		};
-		return fetchRes.json(response)
-			.catch(function(err) {
-				expect(err).to.be.an.instanceof(fetchRes.ReadTimeoutError);
-				expect(err.message).to.equal('response timeout at ...');
-			});
+		return expect(fetchRes.json(response)).to.be.rejectedWith(fetchRes.ReadTimeoutError, 'response timeout at...');
 	});
 
 });

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -38,7 +38,7 @@ describe('fetch', function() {
 				expect(data).to.equal(good);
 			});
 	});
-	
+
 	it('should do the right thing with bad requests', function() {
 		return fetch('https://mattandre.ws/fail.txt')
 			.then(fetchRes.text)
@@ -47,7 +47,7 @@ describe('fetch', function() {
 				expect(err.message).to.equal(410);
 			});
 	});
-	
+
 	it('should facilitate the making of json requests', function() {
 		return fetch('https://mattandre.ws/succeed.json')
 			.then(fetchRes.json)
@@ -55,7 +55,7 @@ describe('fetch', function() {
 				expect(data.text).to.equal(good);
 			});
 	});
-	
+
 	it('should do the right thing with bad json requests', function() {
 		return fetch('https://mattandre.ws/fail.json')
 			.then(fetchRes.json)
@@ -64,7 +64,7 @@ describe('fetch', function() {
 				expect(err.message).to.equal(404);
 			});
 	});
-	
+
 	it('should do the right thing with invalid json responses', function() {
 		return fetch('https://mattandre.ws/invalid.json')
 			.then(fetchRes.json)
@@ -72,7 +72,7 @@ describe('fetch', function() {
 				expect(err).to.be.instanceof(fetchRes.InvalidJsonError);
 			});
 	});
-	
+
 	it('should facilitate the making of many json requests', function() {
 		return Promise.all([
 				fetch('https://mattandre.ws/succeed.json'),
@@ -94,6 +94,20 @@ describe('fetch', function() {
 			.then(function(data) {
 				expect(data[0]).to.equal(good);
 				expect(data[1]).to.equal(good);
+			});
+	});
+
+	it('should throw ReadTimeoutError if json reading times out', function() {
+		var response = {
+			ok: true,
+			json: function() {
+				return Promise.reject(new Error('response timeout at ...'));
+			}
+		};
+		return fetchRes.json(response)
+			.catch(function(err) {
+				expect(err).to.be.an.instanceof(fetchRes.ReadTimeoutError);
+				expect(err.message).to.equal('response timeout at ...');
 			});
 	});
 


### PR DESCRIPTION
`node-fetch` reuses the timeout when reading the response

https://github.com/bitinn/node-fetch/blob/32b60634434a63865ea3f79edb33d17e40876c9f/lib/response.js#L80-L85

Sends a specific error in that case
