### PR TITLE
Add more info to the BadServerResponseError object

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "es6-promise": "^2.0.1",
     "isomorphic-fetch": "^2.0.0",
     "jshint": "^2.5.11",
-    "lintspaces-cli": "0.0.4",
+    "lintspaces-cli": "^0.4.0",
     "mocha": "^2.1.0",
     "nock": "^0.56.0",
     "npm-prepublish": "^1.0.2"

--- a/src/fetchres.js
+++ b/src/fetchres.js
@@ -5,7 +5,7 @@ export function json(response) {
 		return Promise.all(response.map(json));
 	}
 	if (!response.ok) {
-		throw new BadServerResponseError(response.status);
+		throw new BadServerResponseError(response.url, response.status, response.statusText);
 	}
 
 	if (response.status === 204) {
@@ -28,7 +28,7 @@ export function text(response) {
 	}
 
 	if (!response.ok) {
-		throw new BadServerResponseError(response.status);
+		throw new BadServerResponseError(response.url, response.status, response.statusText);
 	}
 
 	if (response.status === 204) {
@@ -41,9 +41,9 @@ export function text(response) {
 export class BadServerResponseError extends Error {
 	// es6 smells
 	// https://twitter.com/andrewsmatt/status/554792707139584001
-	constructor(options) {
+	constructor(url, status, statusText) {
 		super();
-		this.message = options;
+		this.message = `${url} responded with a ${status} (${statusText})`;
 		this.name = 'BadServerResponseError';
 	}
 }

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -53,7 +53,7 @@ describe('fetch', function() {
 			.then(fetchRes.text)
 			.catch(function(err) {
 				expect(err.name).to.equal(fetchRes.BadServerResponseError.name);
-				expect(err.message).to.equal(410);
+				expect(err.message).to.equal('https://mattandre.ws/fail.txt responded with a 410 (Gone)');
 			});
 	});
 
@@ -70,7 +70,7 @@ describe('fetch', function() {
 			.then(fetchRes.json)
 			.catch(function(err) {
 				expect(err.name).to.equal(fetchRes.BadServerResponseError.name);
-				expect(err.message).to.equal(404);
+				expect(err.message).to.equal('https://mattandre.ws/fail.json responded with a 404 (Not Found)');
 			});
 	});
 


### PR DESCRIPTION
Would be great if the error's message contained more info than just the status code

Potential for not being backwards compatible though...
