### PR TITLE
Use `text()` to drain the stream

### DIFF
--- a/src/fetchres.js
+++ b/src/fetchres.js
@@ -5,10 +5,12 @@ export function json(response) {
 		return Promise.all(response.map(json));
 	}
 	if (!response.ok) {
+		response.text();
 		throw new BadServerResponseError(response.url, response.status, response.statusText);
 	}
 
 	if (response.status === 204) {
+		response.text();
 		return undefined;
 	}
 
@@ -28,10 +30,12 @@ export function text(response) {
 	}
 
 	if (!response.ok) {
+		response.text();
 		throw new BadServerResponseError(response.url, response.status, response.statusText);
 	}
 
 	if (response.status === 204) {
+		response.text();
 		return undefined;
 	}
 


### PR DESCRIPTION
Further to https://github.com/matthew-andrews/fetchres/pull/11

Obviously very icky, and not even sure if we need to do this (node-fetch issue is vague)